### PR TITLE
report mode status "off"

### DIFF
--- a/main/heatpump.py
+++ b/main/heatpump.py
@@ -78,18 +78,7 @@ def sub_cb(topic, msg, retained):
 # mode
     elif topic == topic_sub_mode:
         try:
-            message = msg.decode("utf-8")
-            # mode switched to off, power off unit
-            if (message == "off"):
-                values = hpfuncs.stateControl("OFF")
-            else:
-                if power_state != 'ON':
-                    # unit is OFF and some other mode was selected
-                    values = hpfuncs.stateControl("ON")
-                    values = values + hpfuncs.modeControl(msg)
-                else:
-                    # changed mode of running A/C
-                    values = hpfuncs.modeControl(msg)
+            values = hpfuncs.modeControl(msg)
             if values == False:
                 runwrite = False
         except Exception as e:

--- a/main/heatpump.py
+++ b/main/heatpump.py
@@ -210,6 +210,9 @@ async def receiver(client):
                             state = hpfuncs.inttostate[int(data[13])]
                             power_state = state
                             await client.publish(config['maintopic'] + '/state/state', str(state), qos=1)
+                            if (state == "OFF"):
+                                # when power state is OFF, sent unit mode also as "off"
+                                await client.publish(config['maintopic'] + '/mode/state', "off", qos=1)
                         if(str(data[12]) == "160"):
                             fanmode = hpfuncs.inttofanmode[int(data[13])]
                             await client.publish(config['maintopic'] + '/fanmode/state', str(fanmode), qos=1)

--- a/main/hpfuncs.py
+++ b/main/hpfuncs.py
@@ -82,7 +82,7 @@ def fanControl(msg):
 
 def stateControl(msg):
     function_code = 128
-    message = msg.decode("utf-8")
+    message = msg if (type(msg) == str) else msg.decode("utf-8")
     try:
         function_value = statetoint[message]
         control_code = checksum(function_value,function_code)

--- a/main/hpfuncs.py
+++ b/main/hpfuncs.py
@@ -82,7 +82,7 @@ def fanControl(msg):
 
 def stateControl(msg):
     function_code = 128
-    message = msg if (type(msg) == str) else msg.decode("utf-8")
+    message = msg.decode("utf-8")
     try:
         function_value = statetoint[message]
         control_code = checksum(function_value,function_code)


### PR DESCRIPTION
mode status "off" is required for climate control in HomeAssistant to function properly. HA can power on/off the unit automatically via issuing additional power_command topic when necessary. In order to make it work, the unit must report OFF state as `mode/status = off`.

This makes HA UI properly report OFF status and manage auto power on/off.