### PR TITLE
Kazumi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a href="https://www.buymeacoffee.com/toremick2" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>
 
 # shorai-esp32
-This will work for Toshiba Shorai and Seiya
+This will work for Toshiba Shorai, Seiya and Kazumi
 
 This works great for me, but is at your own risk!
 
@@ -89,6 +89,8 @@ mqtt:
         - "fan_only"
       swing_modes:
         - "on"
+#       - "on-h"     # uncomment only for model Kazumi
+#       - "on-vh"    # uncomment only for model Kazumi
         - "off"
       fan_modes:
         - "quiet"

--- a/main/heatpump.py
+++ b/main/heatpump.py
@@ -11,7 +11,7 @@ from config import config
 import time
 from time import sleep
 import machine
-power_state = 'OFF'
+power_state = 'off'
 
 
 
@@ -186,8 +186,8 @@ async def receiver(client):
                             state = hpfuncs.inttostate[int(data[15])]
                             power_state = state
                             await client.publish(config['maintopic'] + '/state/state', str(state), qos=1)
-                            if (state == "OFF"):
-                                # when power state is OFF, sent unit mode also as "off"
+                            if (state == "off"):
+                                # when power state is off, sent unit mode also as "off"
                                 await client.publish(config['maintopic'] + '/mode/state', "off", qos=1)
                         if(str(data[14]) == "160"):
                             fanmode = hpfuncs.inttofanmode[int(data[15])]
@@ -198,7 +198,7 @@ async def receiver(client):
                         if(str(data[14]) == "176"):
                             mode = hpfuncs.inttomode[int(data[15])]
                             # report actual mode when unit is running or "off" when it's not
-                            reportedState = str(mode) if (power_state == "ON") else "off"
+                            reportedState = str(mode) if (power_state == "on") else "off"
                             await client.publish(config['maintopic'] + '/mode/state', reportedState, qos=1) 
                         if(str(data[14]) == "190"):
                             outdoortemp = int_to_signed(int(data[15]))
@@ -214,8 +214,8 @@ async def receiver(client):
                             state = hpfuncs.inttostate[int(data[13])]
                             power_state = state
                             await client.publish(config['maintopic'] + '/state/state', str(state), qos=1)
-                            if (state == "OFF"):
-                                # when power state is OFF, sent unit mode also as "off"
+                            if (state == "off"):
+                                # when power state is off, sent unit mode also as "off"
                                 await client.publish(config['maintopic'] + '/mode/state', "off", qos=1)
                         if(str(data[12]) == "160"):
                             fanmode = hpfuncs.inttofanmode[int(data[13])]
@@ -226,7 +226,7 @@ async def receiver(client):
                         if(str(data[12]) == "176"):
                             mode = hpfuncs.inttomode[int(data[13])]
                             # report actual mode when unit is running or "off" when it's not
-                            reportedState = str(mode) if (power_state == "ON") else "off"
+                            reportedState = str(mode) if (power_state == "on") else "off"
                             await client.publish(config['maintopic'] + '/mode/state', reportedState, qos=1) 
                         if(str(data[12]) == "190"):
                             outdoortemp = int_to_signed(int(data[13]))

--- a/main/heatpump.py
+++ b/main/heatpump.py
@@ -1,5 +1,7 @@
 from main import hpfuncs
+from main.ota_updater import OTAUpdater
 from machine import UART
+
 global uart
 uart = UART(1, 9600)
 uart.init(9600,bits = 8,parity = 0,stop = 1,rx = 32,tx = 33,timeout = 10, timeout_char=50)
@@ -147,8 +149,10 @@ async def firstrun(client):
     firstrun = False
     await asyncio.sleep(10)
     if firstrun == False:
-        await client.publish(config['maintopic'] + '/doinit', "firstrun")
-        hpfuncs.logprint("init firstrun")
+        ota = OTAUpdater(config['your_repo'])
+        current_version = ota.get_version('/main/')
+        await client.publish(config['maintopic'] + '/doinit', "firstrun version " + current_version )
+        hpfuncs.logprint("init firstrun version " + current_version)
         firstrun = True
     while True:
         await asyncio.sleep(60)

--- a/main/heatpump.py
+++ b/main/heatpump.py
@@ -11,7 +11,7 @@ from config import config
 import time
 from time import sleep
 import machine
-power_state = 'off'
+power_state = 'OFF'
 
 
 
@@ -186,8 +186,8 @@ async def receiver(client):
                             state = hpfuncs.inttostate[int(data[15])]
                             power_state = state
                             await client.publish(config['maintopic'] + '/state/state', str(state), qos=1)
-                            if (state == "off"):
-                                # when power state is off, sent unit mode also as "off"
+                            if (state == "OFF"):
+                                # when power state is OFF, sent unit mode also as "off"
                                 await client.publish(config['maintopic'] + '/mode/state', "off", qos=1)
                         if(str(data[14]) == "160"):
                             fanmode = hpfuncs.inttofanmode[int(data[15])]
@@ -198,7 +198,7 @@ async def receiver(client):
                         if(str(data[14]) == "176"):
                             mode = hpfuncs.inttomode[int(data[15])]
                             # report actual mode when unit is running or "off" when it's not
-                            reportedState = str(mode) if (power_state == "on") else "off"
+                            reportedState = str(mode) if (power_state == "ON") else "off"
                             await client.publish(config['maintopic'] + '/mode/state', reportedState, qos=1) 
                         if(str(data[14]) == "190"):
                             outdoortemp = int_to_signed(int(data[15]))
@@ -214,8 +214,8 @@ async def receiver(client):
                             state = hpfuncs.inttostate[int(data[13])]
                             power_state = state
                             await client.publish(config['maintopic'] + '/state/state', str(state), qos=1)
-                            if (state == "off"):
-                                # when power state is off, sent unit mode also as "off"
+                            if (state == "OFF"):
+                                # when power state is OFF, sent unit mode also as "off"
                                 await client.publish(config['maintopic'] + '/mode/state', "off", qos=1)
                         if(str(data[12]) == "160"):
                             fanmode = hpfuncs.inttofanmode[int(data[13])]
@@ -226,7 +226,7 @@ async def receiver(client):
                         if(str(data[12]) == "176"):
                             mode = hpfuncs.inttomode[int(data[13])]
                             # report actual mode when unit is running or "off" when it's not
-                            reportedState = str(mode) if (power_state == "on") else "off"
+                            reportedState = str(mode) if (power_state == "ON") else "off"
                             await client.publish(config['maintopic'] + '/mode/state', reportedState, qos=1) 
                         if(str(data[12]) == "190"):
                             outdoortemp = int_to_signed(int(data[13]))
@@ -251,5 +251,6 @@ loop.create_task(mainloop(client))
 loop.create_task(receiver(client))
 loop.create_task(firstrun(client))
 loop.run_forever()
+
 
 

--- a/main/heatpump.py
+++ b/main/heatpump.py
@@ -100,6 +100,10 @@ def sub_cb(topic, msg, retained):
 ################################################
 # do init
     elif topic == topic_sub_doinit:
+        hpfuncs.logprint(str(msg))
+        if msg == b'reboot':
+            hpfuncs.logprint("rebooting")
+            machine.reset()
         myvals = hpfuncs.queryall()
         hpfuncs.logprint("initial read")
         for i in myvals:
@@ -257,6 +261,7 @@ loop.create_task(mainloop(client))
 loop.create_task(receiver(client))
 loop.create_task(firstrun(client))
 loop.run_forever()
+
 
 
 

--- a/main/heatpump.py
+++ b/main/heatpump.py
@@ -1,6 +1,7 @@
 from main import hpfuncs
 from main.ota_updater import OTAUpdater
 from machine import UART
+from machine import RTC
 
 global uart
 uart = UART(1, 9600)
@@ -156,7 +157,12 @@ async def firstrun(client):
         firstrun = True
     while True:
         await asyncio.sleep(60)
-        await client.publish(config['maintopic'] + '/watchdog', "get")
+        rtc = RTC()
+        t = rtc.datetime()
+        #(2020, 4, 22, 2, 8, 43, 38, 88387)
+        # yyyy, m, dd, ?, h, mm, ss, ms
+        timestamp = str(t[2]) + "-" + str(t[1]) + "-" + str(t[0]) + " " + str(t[4]) + ":" + str(t[5]) + ":" + str(t[6]) + "." + str(t[7])        
+        await client.publish(config['maintopic'] + '/watchdog', timestamp)
         hpfuncs.logprint("running watchdog..")
 
 async def receiver(client):
@@ -251,6 +257,7 @@ loop.create_task(mainloop(client))
 loop.create_task(receiver(client))
 loop.create_task(firstrun(client))
 loop.run_forever()
+
 
 
 

--- a/main/heatpump.py
+++ b/main/heatpump.py
@@ -100,10 +100,6 @@ def sub_cb(topic, msg, retained):
 ################################################
 # do init
     elif topic == topic_sub_doinit:
-        hpfuncs.logprint(str(msg))
-        if msg == b'reboot':
-            hpfuncs.logprint("rebooting")
-            machine.reset()
         myvals = hpfuncs.queryall()
         hpfuncs.logprint("initial read")
         for i in myvals:

--- a/main/heatpump.py
+++ b/main/heatpump.py
@@ -1,7 +1,6 @@
 from main import hpfuncs
 from main.ota_updater import OTAUpdater
 from machine import UART
-from machine import RTC
 
 global uart
 uart = UART(1, 9600)
@@ -157,11 +156,7 @@ async def firstrun(client):
         firstrun = True
     while True:
         await asyncio.sleep(60)
-        rtc = RTC()
-        t = rtc.datetime()
-        #(2020, 4, 22, 2, 8, 43, 38, 88387)
-        # yyyy, m, dd, ?, h, mm, ss, ms
-        timestamp = str(t[2]) + "-" + str(t[1]) + "-" + str(t[0]) + " " + str(t[4]) + ":" + str(t[5]) + ":" + str(t[6]) + "." + str(t[7])        
+        timestamp = str(time.time()+946684800)
         await client.publish(config['maintopic'] + '/watchdog', timestamp)
         hpfuncs.logprint("running watchdog..")
 

--- a/main/hpfuncs.py
+++ b/main/hpfuncs.py
@@ -15,7 +15,7 @@ inttofanmode = dict(map(reversed, fanmodetoint.items()))
 swingtoint = {"off": 49, "on":65, "on-h":66, "on-vh":67}
 inttoswing = dict(map(reversed, swingtoint.items()))
 
-statetoint = {"ON":48, "OFF":49}
+statetoint = {"on":48, "off":49}
 inttostate = dict(map(reversed, statetoint.items()))
 
 def checksum(msg,function):

--- a/main/hpfuncs.py
+++ b/main/hpfuncs.py
@@ -12,7 +12,7 @@ inttomode = dict(map(reversed, modetoint.items()))
 fanmodetoint = {"quiet":49, "lvl_1": 50, "lvl_2":51, "lvl_3":52, "lvl_4":53, "lvl_5":54, "auto":65} 
 inttofanmode = dict(map(reversed, fanmodetoint.items()))
 
-swingtoint = {"off": 49, "on":65}
+swingtoint = {"off": 49, "on":65, "on-h":66, "on-vh":67}
 inttoswing = dict(map(reversed, swingtoint.items()))
 
 statetoint = {"ON":48, "OFF":49}

--- a/main/hpfuncs.py
+++ b/main/hpfuncs.py
@@ -6,7 +6,7 @@ try:
 except Exception as e:
     print(e)
 
-modetoint = {"auto":65, "cool":66, "heat":67, "dry":68, "fan_only":69}
+modetoint = {"off": 49, "auto":65, "cool":66, "heat":67, "dry":68, "fan_only":69}
 inttomode = dict(map(reversed, modetoint.items()))
 
 fanmodetoint = {"quiet":49, "lvl_1": 50, "lvl_2":51, "lvl_3":52, "lvl_4":53, "lvl_5":54, "auto":65} 
@@ -15,7 +15,7 @@ inttofanmode = dict(map(reversed, fanmodetoint.items()))
 swingtoint = {"off": 49, "on":65, "on-h":66, "on-vh":67}
 inttoswing = dict(map(reversed, swingtoint.items()))
 
-statetoint = {"on":48, "off":49}
+statetoint = {"ON":48, "OFF":49}
 inttostate = dict(map(reversed, statetoint.items()))
 
 def checksum(msg,function):
@@ -57,10 +57,23 @@ def modeControl(msg):
     message = msg.decode("utf-8")
     try:
         function_value = modetoint[message]
+
+        control_code = checksum(48,128)
+        pwr_on_mylist = (2,0,3,16,0,0,7,1,48,1,0,2,128,48,control_code)
+        pwr_on_getlist = (2,0,3,16,0,0,6,1,48,1,0,1,128,52)
+        
         control_code = checksum(function_value,function_code)
         mylist = (2,0,3,16,0,0,7,1,48,1,0,2,function_code,function_value,control_code)
         getlist = (2,0,3,16,0,0,6,1,48,1,0,1,function_code,4)
-        myvalues = (mylist, getlist)
+        
+        myvalues = (pwr_on_mylist, pwr_on_getlist, mylist, getlist)
+  
+        if function_value == 49:
+            control_code = checksum(49,128)
+            mylist = (2,0,3,16,0,0,7,1,48,1,0,2,128,49,control_code)
+            getlist = (2,0,3,16,0,0,6,1,48,1,0,1,128,52)    
+            myvalues = (mylist, getlist)
+            
     except Exception as e:
         myvalues = False
     return myvalues


### PR DESCRIPTION
Adding model Kazumi. I have both a Seiya ( RAS-B07J2KVG-E, RAS-07J2AVG-E ) and a Kazumi ( RAS-B22J2KVSG-E, RAS-22J2AVSG-E ).
Key of this change is the additional swingmode control codes, see heatpump.py, swingtoint = {"off": 49, "on":65, "on-h":66, "on-vh":67} .
Kazumi has also two horizontal swingmodes (I called them 'on-v' and 'on-vh'). When the unit responses with one of those two swingmode states, the original code crashes. You won't see the crash through the mqtt messages, only when using serial. You will see 'Exception occurred', preceded by the unknown control code '66' or '67'.
I have also added the version number to the firstrun message.
The Homeassistant Climate config can be updated to handle 'on-v' and 'on-vh', remove comment when needed.